### PR TITLE
Fix pubKeyHashToAddress to calculate address properly

### DIFF
--- a/src/providers/bitcoin/BitcoinUtil.js
+++ b/src/providers/bitcoin/BitcoinUtil.js
@@ -44,8 +44,8 @@ function pubKeyToAddress (pubKey, network, type) {
 function pubKeyHashToAddress (pubKeyHash, network, type) {
   pubKeyHash = ensureBuffer(pubKeyHash)
   const prefixHash = Buffer.concat([Buffer.from(networks[network][type], 'hex'), pubKeyHash])
-  const checksum = Buffer.from(sha256(sha256(prefixHash)).slice(0, 4), 'hex')
-  const addr = base58.encode(Buffer.concat([prefixHash, checksum]))
+  const checksum = Buffer.from(sha256(sha256(prefixHash)).slice(0, 8), 'hex')
+  const addr = base58.encode(Buffer.concat([prefixHash, checksum]).slice(0, 25))
   return addr
 }
 


### PR DESCRIPTION
This PR fixes issues with convert `pubKeyHash` to `address` an accounts for proper checksum size and base58 decode bytesize. 
