### PR TITLE
Update metamask and ethereum rpc provider to new jsonrpc

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -359,6 +359,16 @@ export default class Client {
   }
 
   /**
+   * Get unused address/account of the user.
+   * @return {Promise<string, InvalidProviderResponseError>} Resolves with a address
+   *  object.
+   *  Rejects with InvalidProviderResponseError if provider's response is invalid.
+   */
+  async getUnusedAddress (from = {}) {
+    return this.getMethod('getUnusedAddress')(from)
+  }
+
+  /**
    * Sign a message.
    * @param {!string} message - Message to be signed.
    * @param {!string} from - The address from which the message is signed.

--- a/src/providers/bitcoin/BitcoinLedgerProvider.js
+++ b/src/providers/bitcoin/BitcoinLedgerProvider.js
@@ -121,7 +121,7 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
       const path = this.getDerivationPathFromIndex(addressIndex)
       const address = await this.getAddressFromDerivationPath(path)
       const utxos = await this.getMethod('getUnspentTransactions')(address.address)
-      const utxosValue = utxos.reduce((acc, utxo) => acc + utxo.value, 0)
+      const utxosValue = utxos.reduce((acc, utxo) => acc + (utxo.amount * 1e8), 0)
 
       utxos.forEach((utxo) => {
         currentAmount += utxosValue
@@ -167,7 +167,7 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
     const unusedAddress = await this.getUnusedAddress(from)
     const unspentOutputsToUse = await this.getUtxosForAmount(value)
 
-    const totalAmount = unspentOutputsToUse.reduce((acc, utxo) => acc + utxo.amount * 1e8, 0)
+    const totalAmount = unspentOutputsToUse.reduce((acc, utxo) => acc + (utxo.amount * 1e8), 0)
     const fee = this.calculateFee(unspentOutputsToUse.length, 1, 3)
     let totalCost = value + fee
     let hasChange = false

--- a/src/providers/bitcoin/BitcoinRPCProvider.js
+++ b/src/providers/bitcoin/BitcoinRPCProvider.js
@@ -23,9 +23,13 @@ export default class BitcoinRPCProvider extends JsonRpcProvider {
     addresses = addresses
       .map(address => String(address))
 
-    const _utxos = await Promise.all(addresses.map(address => this.getUnspentTransactions(address)))
+    const _utxos = await this.getUnspentTransactionsForAddresses(addresses)
     const utxos = flatten(_utxos)
     return utxos.reduce((acc, utxo) => acc + (utxo.amount * 1e8), 0)
+  }
+
+  async getUnspentTransactionsForAddresses (addresses) {
+    return this.jsonrpc('listunspent', 0, 9999999, addresses)
   }
 
   async getUnspentTransactions (address) {
@@ -77,7 +81,7 @@ export default class BitcoinRPCProvider extends JsonRpcProvider {
   }
 
   async getBlockHeight () {
-    return this.rpc('getblockcount')
+    return this.jsonrpc('getblockcount')
   }
 
   async getTransactionByHash (transactionHash) {

--- a/src/providers/ethereum/EthereumMetaMaskProvider.js
+++ b/src/providers/ethereum/EthereumMetaMaskProvider.js
@@ -42,15 +42,18 @@ export default class EthereumMetaMaskProvider extends Provider {
   }
 
   async getAddresses () {
-    return this._toMM('eth_accounts')
+    const addresses = await this._toMM('eth_accounts')
+
+    return addresses.map((address) => { return { address: address } })
   }
 
   async getUsedAddresses (startingIndex, numAddresses) {
     return this.getAddresses()
   }
 
-  async getUnusedAddresses (startingIndex, numAddresses) {
-    return []
+  async getUnusedAddress () {
+    const addresses = await this.getAddresses()
+    return addresses[0]
   }
 
   async signMessage (message, from) {
@@ -68,7 +71,7 @@ export default class EthereumMetaMaskProvider extends Provider {
 
     if (from == null) {
       const addresses = await this.getAddresses()
-      from = ensureHexEthFormat(addresses[0])
+      from = ensureHexEthFormat(addresses[0].address)
     }
 
     value = BigNumber(value).toString(16)

--- a/src/providers/ethereum/EthereumRPCProvider.js
+++ b/src/providers/ethereum/EthereumRPCProvider.js
@@ -23,7 +23,7 @@ export default class EthereumRPCProvider extends JsonRpcProvider {
   }
 
   async getBlockHeight () {
-    const hexHeight = await this.rpc('eth_blockNumber')
+    const hexHeight = await this.jsonrpc('eth_blockNumber')
     return parseInt(hexHeight, '16')
   }
 
@@ -34,7 +34,7 @@ export default class EthereumRPCProvider extends JsonRpcProvider {
 
   async getTransactionReceipt (txHash) {
     txHash = ensureHexEthFormat(txHash)
-    return this.rpc('eth_getTransactionReceipt', txHash)
+    return this.jsonrpc('eth_getTransactionReceipt', txHash)
   }
 
   async getBalance (addresses) {
@@ -42,7 +42,7 @@ export default class EthereumRPCProvider extends JsonRpcProvider {
       .map(address => String(address))
 
     const addrs = addresses.map(ensureHexEthFormat)
-    const promiseBalances = await Promise.all(addrs.map(address => this.rpc('eth_getBalance', address, 'latest')))
+    const promiseBalances = await Promise.all(addrs.map(address => this.jsonrpc('eth_getBalance', address, 'latest')))
     return promiseBalances.map(balance => parseInt(balance, 16))
       .reduce((acc, balance) => acc + balance, 0)
   }
@@ -50,7 +50,7 @@ export default class EthereumRPCProvider extends JsonRpcProvider {
   async isAddressUsed (address) {
     address = String(address)
 
-    const transactionCount = this.rpc('getTransactionCount', address)
+    const transactionCount = this.jsonrpc('getTransactionCount', address)
 
     return transactionCount > 0
   }


### PR DESCRIPTION
### Description

This PR updates metamask and ethereum rpc provider to use new jsonrpc class and ensures ethereum swap is fully functioning. 


### Submission Checklist :pencil:

- [x] replace `rpc` with `jsonrpc`
- [x] `getUnspentTransactionsForAddresses`
- [x] `getAddresses` formatting