### PR TITLE
Swap providers: finding transaction ensures correct value locked

### DIFF
--- a/examples/swap/swap-e2e.html
+++ b/examples/swap/swap-e2e.html
@@ -94,52 +94,40 @@
     }
 
     function initiateSwap (client, prefix) {
-      client.createSwapScript(
-        $(`#${prefix}RecipientAddress`).val(),
-        $(`#${prefix}RefundAddress`).val(),
-        $(`#${prefix}SecretHash`).val(),
-        parseInt($(`#${prefix}Expiration`).val())
-      ).then(result => {
+      const recipientAddress = $(`#${prefix}RecipientAddress`).val()
+      const refundAddress = $(`#${prefix}RefundAddress`).val()
+      const secretHash = $(`#${prefix}SecretHash`).val()
+      const expiration = parseInt($(`#${prefix}Expiration`).val())
+      const value = parseInt($(`#${prefix}FundValue`).val())
+
+      client.createSwapScript(recipientAddress, refundAddress, secretHash, expiration).then(result => {
         $(`#${prefix}SwapBytecode`).text(result)
       })
 
-      client.initiateSwap(
-        parseInt($(`#${prefix}FundValue`).val()),
-        $(`#${prefix}RecipientAddress`).val(),
-        $(`#${prefix}RefundAddress`).val(),
-        $(`#${prefix}SecretHash`).val(),
-        parseInt($(`#${prefix}Expiration`).val())
-      ).then(result => {
+      client.initiateSwap(value, recipientAddress, refundAddress, secretHash, expiration).then(result => {
         $(`#${prefix}InitiateSwapResult`).text(result)
         $(`#${prefix}FindInitiateSwap`).show()
       })
 
-      client.findInitiateSwapTransaction(
-        $(`#${prefix}RecipientAddress`).val(),
-        $(`#${prefix}RefundAddress`).val(),
-        $(`#${prefix}SecretHash`).val(),
-        parseInt($(`#${prefix}Expiration`).val())
-      ).then(result => {
+      client.findInitiateSwapTransaction(value, recipientAddress, refundAddress, secretHash, expiration).then(result => {
         $(`#${prefix}FindInitiateSwapTransactionResult`).text(JSON.stringify(result, null, 2))
       })
     }
 
     function claimSwap (client, prefix) {
-      client.claimSwap(
-        $(`#${prefix}InitiationTxHash`).val(),
-        $(`#${prefix}RecipientAddress`).val(),
-        $(`#${prefix}RefundAddress`).val(),
-        $(`#${prefix}ClaimSecret`).val(),
-        parseInt($(`#${prefix}Expiration`).val())
-      ).then(result => {
+      const initiationTxHash = $(`#${prefix}InitiationTxHash`).val()
+      const secret = $(`#${prefix}ClaimSecret`).val()
+      const recipientAddress = $(`#${prefix}RecipientAddress`).val()
+      const refundAddress = $(`#${prefix}RefundAddress`).val()
+      const secretHash = $(`#${prefix}SecretHash`).val()
+      const expiration = parseInt($(`#${prefix}Expiration`).val())
+
+      client.claimSwap(initiationTxHash, recipientAddress, refundAddress, secret, expiration).then(result => {
         $(`#${prefix}ClaimSwapResult`).text(result)
         $(`#${prefix}FindClaimSwap`).show()
       })
 
-      client.findClaimSwapTransaction(
-        $(`#${prefix}InitiationTxHash`).val(),
-        $(`#${prefix}SecretHash`).val()
-      ).then(result => {
+      client.findClaimSwapTransaction(initiationTxHash, secretHash).then(result => {
         $(`#${prefix}FindClaimSwapTransactionResult`).text(JSON.stringify(result, null, 2))
         $(`#${prefix}FindClaimSwapTransactionResultSecret`).text(result.secret)
         $(`#${prefix}FindClaimSwapSecret`).show()

--- a/src/Client.js
+++ b/src/Client.js
@@ -422,14 +422,15 @@ export default class Client {
 
   /**
    * Find swap transaction from parameters
+   * @param {!number} value - The amount of native value locked in the swap
    * @param {!string} blockNumber - Block number in which transaction was mined
    * @param {!string} recipientAddress - Recepient address
    * @param {!string} refundAddress - Refund address
    * @param {!string} expiration - Expiration time
    * @return {Promise<string>} Resolves with a transaction identifier.
    */
-  async findInitiateSwapTransaction (recipientAddress, refundAddress, secretHash, expiration) {
-    return this.getMethod('findInitiateSwapTransaction')(recipientAddress, refundAddress, secretHash, expiration)
+  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration) {
+    return this.getMethod('findInitiateSwapTransaction')(value, recipientAddress, refundAddress, secretHash, expiration)
   }
 
   /**

--- a/src/providers/bitcoin/BitcoinSwapProvider.js
+++ b/src/providers/bitcoin/BitcoinSwapProvider.js
@@ -131,7 +131,7 @@ export default class BitcoinSwapProvider extends Provider {
     return this._spendSwap(signature, pubKey, false)
   }
 
-  async findInitiateSwapTransaction (recipientAddress, refundAddress, secretHash, expiration) {
+  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration) {
     const data = this.createSwapScript(recipientAddress, refundAddress, secretHash, expiration)
     const scriptPubKey = padHexStart(data)
     const receivingAddress = pubKeyToAddress(scriptPubKey, this._network.name, 'scriptHash')
@@ -152,9 +152,9 @@ export default class BitcoinSwapProvider extends Provider {
         initiateSwapTransaction = txs
           .map(transaction => transaction._raw.data)
           .map(transaction => transaction.vout
-            .map(vout => { return { txid: transaction.txid, scriptPubKey: vout.scriptPubKey } }))
+            .map(vout => { return { txid: transaction.txid, scriptPubKey: vout.scriptPubKey, value: vout.valueSat } }))
           .reduce((acc, val) => acc.concat(val), [])
-          .find(txKeys => txKeys.scriptPubKey.hex === sendScript)
+          .find(txInfo => txInfo.scriptPubKey.hex === sendScript && txInfo.value === value)
         blockNumber++
       }
       await sleep(5000)

--- a/src/providers/ethereum/EthereumSwapProvider.js
+++ b/src/providers/ethereum/EthereumSwapProvider.js
@@ -95,14 +95,16 @@ export default class EthereumSwapProvider extends Provider {
     return ''
   }
 
-  async findInitiateSwapTransaction (recipientAddress, refundAddress, secretHash, expiration) {
+  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration) {
     const data = this.createSwapScript(recipientAddress, refundAddress, secretHash, expiration)
     let blockNumber = await this.getMethod('getBlockHeight')()
     let initiateSwapTransaction = null
     while (!initiateSwapTransaction) {
       const block = await this.getMethod('getBlockByNumber')(blockNumber, true)
       if (block) {
-        initiateSwapTransaction = block.transactions.find(transaction => transaction.input === data.toLowerCase())
+        initiateSwapTransaction = block.transactions.find(transaction =>
+          transaction.input === data.toLowerCase() && transaction.value === value
+        )
         blockNumber++
       }
       await sleep(5000)


### PR DESCRIPTION
### Description

Bug: the finding of the initiate transaction does not check the value locked using the transaction. It would open potential attack vectors. 

### Submission Checklist :pencil:

- [x] Check the value locked in the swap when finding/verifying an initiation transaction
