### PR TITLE
Add verify swap method

### DIFF
--- a/examples/swap/swap-e2e.html
+++ b/examples/swap/swap-e2e.html
@@ -35,6 +35,15 @@
         <p>swap bytecode: <textarea id="btcSwapBytecode"></textarea></p>
         <p>transaction hash: <textarea id="btcInitiateSwapResult"></textarea></p>
         <p style="color: red; display: none;" id="btcFindInitiateSwap">Scanning for initiation tx: <textarea id="btcFindInitiateSwapTransactionResult"></textarea></p>
+        <h3>Verify swap:</h3>
+        <p><strong>Wait until initiation transaction has been confirmed!</strong></p>
+        <p><strong style="color:dodgerblue">Change initiation fields above to play with verification of swap</strong></p>
+        <p>initiationTxHash: <input type="text" id="btcInitiationTxHashVerify" /></p>
+        <p>
+          <button id="btcVerifySwap">Verify Swap</button>
+          <img style="display:none" id="btcVerifySwapTrue" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAACHElEQVRIS+2VPU/bQBjH/5dA6teEDpWqdmThG3RoJip1Z2eq8hm68rL3G9BurHyASnSCod+gC0srkJCIII7t2Djxof/hC+fYJFERG5YenXM6/37PPc/ZEXjmSzwzHy8CVeEvPz++a6yI83ws3//4fHphlv3JJdLw9Y11nP05w6zkSQITnmYpkizB1d+rkuS/BXVwXRpKDjZPFLsimFdPDTDhyW2iMhfiHkU4JPYOPp3sVgSL6mk2lDUfpSMkaQI0oAT9f/0SvCTQ8LW3a7AtG47lVJpmJhCPYsRJrMCiIXB9cV2BlwS9X11JuJQSMpdwbAeu404lXMyjyMyjKEIURwrMGFwOauFlwXF3FwI77Tdt5HmuJJ7rwfM8JeFFeDgMMYyG08zDfvgovNKDXiFxX7tKwPB9H37bV4IgCDAMHuDxIJ4Lrz1FWmL51lTS6XQgIRHcBOrcsSxplC6E1wo4qSUtu3UvkXL69rOpWZotBX9UYEqaq03ClITwyXiyNHyuwJSwJFpivkTL/Jcs+lSI3nF3h6eLMAm5/33zdG8GrOv3UEdjgSngfQPACoDVYmxybvvow1cpIA63fn8zniWQkRcxATAGkBUj56UpILwFwAPAc2kVIkqUqPh28RkTTjCD4BGAsIhbimcFzN4G4AB4ZezCFOhN6Oy1gNmnAOJCxN8lgW46M9Why8axrl/mTnhPmRarnixq8jIHZe6aO75QNCiLJ0zzAAAAAElFTkSuQmCC" />
+          <img style="display:none" id="btcVerifySwapFalse" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAACT0lEQVRIS8WVS2sTURTHf2N8JMG2iK/W4luhKkpRSqmvb6BfoNCVazcKbsRUN4Li1oVLwS9Qv4GvEKqlKNWitmqTaavNQ6skrUlz5Qxzp8nMnWk3wYHLZOae8/+dxz0TixZfVov1+b8Am+SlbspPo7JcyyY0A3G0YETB5TDIemyMAO3Ydf4scy9eYYJ4NkODzD1+YrSRzAMA7dh5bsCrzPzLdJNAozilEqpYwm+jnQOAWZKqc6A/UPb5dMaBuFGNdA0NQrGIKhRXA0ln2EO5SdOUwbAFqd39fQHI98yo807EVaGAyhc8G9lTcLub8nCjY1gPHMiuvjMBSOxYDyqfp76Q9/Z+jL4xiht7oL1skg5k5+neyFlcGBsPFY8EyKaG7Og9ZYTkx99Giq8JEANp+vaTJ4yAwruJQFP9hpGfChGXhi6/HgstU/H9h0hIKECL1+xZarbtAJRpcIDS5MdQiBGgxas5m2o250X/69Nn53fH0SOBjGTPPwPGHnji2RzVmeyq+NS001DXKdVx+FAQMjW9/kFrP3jAE1j88rXptOjTFWWjnSMHrW3/Pn5/m2EF7uyl7ESvryzJVAxuaRvTFPtLJLANwEZg0ySJm+1YN36i7h+n8sDtb2NAaoLEtW1Y1xdR93qo3AVqQNW91+VcNDqI+GZgK9AGxJ8Rv3qRpUdAzIWLvSw5ULLqz4lfucDSQ1e4Avxx11/Z9wMk+gSQBLa42Yh4I0BXyQGAVNBZEv0yUAYEJM9NAF0yyUQvXTYduf/keJm4GQlIg+Xe+j/9fwC4AyiJR4XmAAAAAElFTkSuQmCC" />
+        </p>
         <h3>Claim swap:</h3>
         <p><strong>Wait until initiation transaction has been confirmed!</strong></p>
         <p>secret: <input type="text" id="btcClaimSecret" /></p>
@@ -60,6 +69,15 @@
         <p>swap bytecode: <textarea id="ethSwapBytecode"></textarea></p>
         <p>transaction hash: <textarea id="ethInitiateSwapResult"></textarea></p>
         <p style="color: red; display: none;" id="ethFindInitiateSwap">Scanning for initiation tx: <textarea id="ethFindInitiateSwapTransactionResult"></textarea></p>
+        <h3>Verify swap:</h3>
+        <p><strong>Wait until initiation transaction has been confirmed!</strong></p>
+        <p><strong style="color:dodgerblue">Change initiation fields above to play with verification of swap</strong></p>
+        <p>initiationTxHash: <input type="text" id="ethInitiationTxHashVerify" /></p>
+        <p>
+          <button id="ethVerifySwap">Verify Swap</button>
+          <img style="display:none" id="ethVerifySwapTrue" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAACHElEQVRIS+2VPU/bQBjH/5dA6teEDpWqdmThG3RoJip1Z2eq8hm68rL3G9BurHyASnSCod+gC0srkJCIII7t2Djxof/hC+fYJFERG5YenXM6/37PPc/ZEXjmSzwzHy8CVeEvPz++a6yI83ws3//4fHphlv3JJdLw9Y11nP05w6zkSQITnmYpkizB1d+rkuS/BXVwXRpKDjZPFLsimFdPDTDhyW2iMhfiHkU4JPYOPp3sVgSL6mk2lDUfpSMkaQI0oAT9f/0SvCTQ8LW3a7AtG47lVJpmJhCPYsRJrMCiIXB9cV2BlwS9X11JuJQSMpdwbAeu404lXMyjyMyjKEIURwrMGFwOauFlwXF3FwI77Tdt5HmuJJ7rwfM8JeFFeDgMMYyG08zDfvgovNKDXiFxX7tKwPB9H37bV4IgCDAMHuDxIJ4Lrz1FWmL51lTS6XQgIRHcBOrcsSxplC6E1wo4qSUtu3UvkXL69rOpWZotBX9UYEqaq03ClITwyXiyNHyuwJSwJFpivkTL/Jcs+lSI3nF3h6eLMAm5/33zdG8GrOv3UEdjgSngfQPACoDVYmxybvvow1cpIA63fn8zniWQkRcxATAGkBUj56UpILwFwAPAc2kVIkqUqPh28RkTTjCD4BGAsIhbimcFzN4G4AB4ZezCFOhN6Oy1gNmnAOJCxN8lgW46M9Why8axrl/mTnhPmRarnixq8jIHZe6aO75QNCiLJ0zzAAAAAElFTkSuQmCC" />
+          <img style="display:none" id="ethVerifySwapFalse" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAACT0lEQVRIS8WVS2sTURTHf2N8JMG2iK/W4luhKkpRSqmvb6BfoNCVazcKbsRUN4Li1oVLwS9Qv4GvEKqlKNWitmqTaavNQ6skrUlz5Qxzp8nMnWk3wYHLZOae8/+dxz0TixZfVov1+b8Am+SlbspPo7JcyyY0A3G0YETB5TDIemyMAO3Ydf4scy9eYYJ4NkODzD1+YrSRzAMA7dh5bsCrzPzLdJNAozilEqpYwm+jnQOAWZKqc6A/UPb5dMaBuFGNdA0NQrGIKhRXA0ln2EO5SdOUwbAFqd39fQHI98yo807EVaGAyhc8G9lTcLub8nCjY1gPHMiuvjMBSOxYDyqfp76Q9/Z+jL4xiht7oL1skg5k5+neyFlcGBsPFY8EyKaG7Og9ZYTkx99Giq8JEANp+vaTJ4yAwruJQFP9hpGfChGXhi6/HgstU/H9h0hIKECL1+xZarbtAJRpcIDS5MdQiBGgxas5m2o250X/69Nn53fH0SOBjGTPPwPGHnji2RzVmeyq+NS001DXKdVx+FAQMjW9/kFrP3jAE1j88rXptOjTFWWjnSMHrW3/Pn5/m2EF7uyl7ESvryzJVAxuaRvTFPtLJLANwEZg0ySJm+1YN36i7h+n8sDtb2NAaoLEtW1Y1xdR93qo3AVqQNW91+VcNDqI+GZgK9AGxJ8Rv3qRpUdAzIWLvSw5ULLqz4lfucDSQ1e4Avxx11/Z9wMk+gSQBLa42Yh4I0BXyQGAVNBZEv0yUAYEJM9NAF0yyUQvXTYduf/keJm4GQlIg+Xe+j/9fwC4AyiJR4XmAAAAAElFTkSuQmCC" />
+        </p>
         <h3>Claim swap:</h3>
         <p><strong>Wait until initiation transaction has been confirmed!</strong></p>
         <p>secret: <input type="text" id="ethClaimSecret" /></p>
@@ -114,6 +132,25 @@
       })
     }
 
+    function verifySwap (client, prefix) {
+      const initiationTxHash = $(`#${prefix}InitiationTxHashVerify`).val()
+      const value = parseInt($(`#${prefix}FundValue`).val())
+      const recipientAddress = $(`#${prefix}RecipientAddress`).val()
+      const refundAddress = $(`#${prefix}RefundAddress`).val()
+      const secretHash = $(`#${prefix}SecretHash`).val()
+      const expiration = parseInt($(`#${prefix}Expiration`).val())
+
+      client.verifyInitiateSwapTransaction(initiationTxHash, value, recipientAddress, refundAddress, secretHash, expiration).then(result => {
+        if (result) {
+          $(`#${prefix}VerifySwapTrue`).show()
+          $(`#${prefix}VerifySwapFalse`).hide()
+        } else {
+          $(`#${prefix}VerifySwapFalse`).show()
+          $(`#${prefix}VerifySwapTrue`).hide()
+        }
+      })
+    }
+
     function claimSwap (client, prefix) {
       const initiationTxHash = $(`#${prefix}InitiationTxHash`).val()
       const secret = $(`#${prefix}ClaimSecret`).val()
@@ -136,10 +173,12 @@
 
     $('#btcGenerateSecret').click(generateSecret.bind(null, bitcoin, 'btc'))
     $('#btcInitiateSwap').click(initiateSwap.bind(null, bitcoin, 'btc'))
+    $('#btcVerifySwap').click(verifySwap.bind(null, bitcoin, 'btc'))
     $('#btcClaimSwap').click(claimSwap.bind(null, bitcoin, 'btc'))
 
     $('#ethGenerateSecret').click(generateSecret.bind(null, ethereum, 'eth'))
     $('#ethInitiateSwap').click(initiateSwap.bind(null, ethereum, 'eth'))
+    $('#ethVerifySwap').click(verifySwap.bind(null, ethereum, 'eth'))
     $('#ethClaimSwap').click(claimSwap.bind(null, ethereum, 'eth'))
   </script>
 </body>

--- a/examples/swap/swap-e2e.html
+++ b/examples/swap/swap-e2e.html
@@ -94,52 +94,40 @@
     }
 
     function initiateSwap (client, prefix) {
-      client.createSwapScript(
-        $(`#${prefix}RecipientAddress`).val(),
-        $(`#${prefix}RefundAddress`).val(),
-        $(`#${prefix}SecretHash`).val(),
-        parseInt($(`#${prefix}Expiration`).val())
-      ).then(result => {
+      const recipientAddress = $(`#${prefix}RecipientAddress`).val()
+      const refundAddress = $(`#${prefix}RefundAddress`).val()
+      const secretHash = $(`#${prefix}SecretHash`).val()
+      const expiration = parseInt($(`#${prefix}Expiration`).val())
+      const value = parseInt($(`#${prefix}FundValue`).val())
+
+      client.createSwapScript(recipientAddress, refundAddress, secretHash, expiration).then(result => {
         $(`#${prefix}SwapBytecode`).text(result)
       })
 
-      client.initiateSwap(
-        parseInt($(`#${prefix}FundValue`).val()),
-        $(`#${prefix}RecipientAddress`).val(),
-        $(`#${prefix}RefundAddress`).val(),
-        $(`#${prefix}SecretHash`).val(),
-        parseInt($(`#${prefix}Expiration`).val())
-      ).then(result => {
+      client.initiateSwap(value, recipientAddress, refundAddress, secretHash, expiration).then(result => {
         $(`#${prefix}InitiateSwapResult`).text(result)
         $(`#${prefix}FindInitiateSwap`).show()
       })
 
-      client.findInitiateSwapTransaction(
-        $(`#${prefix}RecipientAddress`).val(),
-        $(`#${prefix}RefundAddress`).val(),
-        $(`#${prefix}SecretHash`).val(),
-        parseInt($(`#${prefix}Expiration`).val())
-      ).then(result => {
+      client.findInitiateSwapTransaction(value, recipientAddress, refundAddress, secretHash, expiration).then(result => {
         $(`#${prefix}FindInitiateSwapTransactionResult`).text(JSON.stringify(result, null, 2))
       })
     }
 
     function claimSwap (client, prefix) {
-      client.claimSwap(
-        $(`#${prefix}InitiationTxHash`).val(),
-        $(`#${prefix}RecipientAddress`).val(),
-        $(`#${prefix}RefundAddress`).val(),
-        $(`#${prefix}ClaimSecret`).val(),
-        parseInt($(`#${prefix}Expiration`).val())
-      ).then(result => {
+      const initiationTxHash = $(`#${prefix}InitiationTxHash`).val()
+      const secret = $(`#${prefix}ClaimSecret`).val()
+      const recipientAddress = $(`#${prefix}RecipientAddress`).val()
+      const refundAddress = $(`#${prefix}RefundAddress`).val()
+      const secretHash = $(`#${prefix}SecretHash`).val()
+      const expiration = parseInt($(`#${prefix}Expiration`).val())
+
+      client.claimSwap(initiationTxHash, recipientAddress, refundAddress, secret, expiration).then(result => {
         $(`#${prefix}ClaimSwapResult`).text(result)
         $(`#${prefix}FindClaimSwap`).show()
       })
 
-      client.findClaimSwapTransaction(
-        $(`#${prefix}InitiationTxHash`).val(),
-        $(`#${prefix}SecretHash`).val()
-      ).then(result => {
+      client.findClaimSwapTransaction(initiationTxHash, secretHash).then(result => {
         $(`#${prefix}FindClaimSwapTransactionResult`).text(JSON.stringify(result, null, 2))
         $(`#${prefix}FindClaimSwapTransactionResultSecret`).text(result.secret)
         $(`#${prefix}FindClaimSwapSecret`).show()

--- a/src/Client.js
+++ b/src/Client.js
@@ -509,10 +509,32 @@ export default class Client {
   }
 
   /**
-   * Generate redeem swap transaction data
+   * Verifies that the given initiation transaction matches the given swap params
+   * @param {!string} initiationTxHash - The transaction hash of the swap initiation.
+   * @param {!number} value - The amount of native value locked in the swap.
+   * @param {!string} recipientAddress - Recepient address for the swap in hex.
+   * @param {!string} refundAddress - Refund address for the swap in hex.
+   * @param {!string} secretHash - Secret hash for the swap in hex.
+   * @param {!number} expiration - Expiration time for the swap.
+   * @return {Promise<boolean, TypeError>} Resolves with true if verification has passed.
+   *  Rejects with InvalidProviderResponseError if provider's response is invalid.
+   */
+  async verifyInitiateSwapTransaction (initiationTxHash, value, recipientAddress, refundAddress, secretHash, expiration) {
+    if (!(/^[A-Fa-f0-9]+$/.test(initiationTxHash))) {
+      throw new TypeError('Initiation transaction hash should be a valid hex string')
+    }
+
+    return this.getMethod('verifyInitiateSwapTransaction')(initiationTxHash, value, recipientAddress, refundAddress, secretHash, expiration)
+  }
+
+  /**
+   * Claim the swap
+   * @param {!string} initiationTxHash - The transaction hash of the swap initiation.
    * @param {!string} secret - Secret for the swap in hex.
-   * @param {string} [pubKey] - PubKey for the swap in hex.
-   * @param {string} [signature] - Signature for the swap in hex.
+   * @param {!string} recipientAddress - Recepient address for the swap in hex.
+   * @param {!string} refundAddress - Refund address for the swap in hex.
+   * @param {!string} secret - Secret for the swap in hex.
+   * @param {!number} expiration - Expiration time for the swap.
    * @return {Promise<string, TypeError>} Resolves with redeem swap contract bytecode.
    *  Rejects with InvalidProviderResponseError if provider's response is invalid.
    */
@@ -549,19 +571,5 @@ export default class Client {
     }
 
     return this.getMethod('refundSwap')(pubKey, signature)
-  }
-
-  /**
-   * Check if counterparty transaction has been confirmed
-   * @param {!number} blockNumber - The number of the desired block.
-   * @param {!string} recipientAddress - Recepient address for the swap in hex.
-   * @param {!string} refundAddress - Refund address for the swap in hex.
-   * @param {!string} secretHash - Secret hash for the swap in hex.
-   * @param {!number} expiration - Expiration time for the swap.
-   * @return {Promise<string, TypeError>} Resolves with txHash of desired swap or false if not found.
-   *  Rejects with InvalidProviderResponseError if provider's response is invalid.
-   */
-  async checkBlockSwap (blockNumber, recipientAddress, refundAddress, secretHash, expiration) {
-    return this.getMethod('checkBlockSwap')(blockNumber, recipientAddress, refundAddress, secretHash, expiration)
   }
 }

--- a/src/Client.js
+++ b/src/Client.js
@@ -422,14 +422,15 @@ export default class Client {
 
   /**
    * Find swap transaction from parameters
+   * @param {!number} value - The amount of native value locked in the swap
    * @param {!string} blockNumber - Block number in which transaction was mined
    * @param {!string} recipientAddress - Recepient address
    * @param {!string} refundAddress - Refund address
    * @param {!string} expiration - Expiration time
    * @return {Promise<string>} Resolves with a transaction identifier.
    */
-  async findInitiateSwapTransaction (recipientAddress, refundAddress, secretHash, expiration) {
-    return this.getMethod('findInitiateSwapTransaction')(recipientAddress, refundAddress, secretHash, expiration)
+  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration) {
+    return this.getMethod('findInitiateSwapTransaction')(value, recipientAddress, refundAddress, secretHash, expiration)
   }
 
   /**

--- a/src/providers/bitcoin/BitcoinRPCProvider.js
+++ b/src/providers/bitcoin/BitcoinRPCProvider.js
@@ -59,7 +59,7 @@ export default class BitcoinRPCProvider extends JsonRpcProvider {
     let { tx: transactions } = data
 
     if (includeTx) {
-      const txs = transactions.map(this.getMethod('getRawTransactionByHash'))
+      const txs = transactions.map(this.getMethod('getTransactionByHash'))
       transactions = await Promise.all(txs)
     }
 

--- a/src/providers/bitcoin/BitcoinSwapProvider.js
+++ b/src/providers/bitcoin/BitcoinSwapProvider.js
@@ -145,24 +145,15 @@ export default class BitcoinSwapProvider extends Provider {
         block = await this.getMethod('getBlockByNumber')(blockNumber, true)
       } catch (e) { }
       if (block) {
-        const transactions = block.transactions
-        const txs = await Promise.all(transactions.map(async transaction => {
-          return this.getMethod('decodeRawTransaction')(transaction)
-        }))
-        initiateSwapTransaction = txs
-          .map(transaction => transaction._raw.data)
-          .map(transaction => transaction.vout
-            .map(vout => { return { txid: transaction.txid, scriptPubKey: vout.scriptPubKey, value: vout.valueSat } }))
-          .reduce((acc, val) => acc.concat(val), [])
-          .find(txInfo => txInfo.scriptPubKey.hex === sendScript && txInfo.value === value)
+        initiateSwapTransaction = block.transactions.find(tx =>
+          tx._raw.data.vout.find(vout => vout.scriptPubKey.hex === sendScript && vout.valueSat === value)
+        )
         blockNumber++
       }
       await sleep(5000)
     }
 
-    return {
-      hash: initiateSwapTransaction.txid // TODO: full transaction object
-    }
+    return initiateSwapTransaction
   }
 
   async findClaimSwapTransaction (initiationTxHash, secretHash) {
@@ -174,15 +165,9 @@ export default class BitcoinSwapProvider extends Provider {
         block = await this.getMethod('getBlockByNumber')(blockNumber, true)
       } catch (e) { }
       if (block) {
-        const transactions = block.transactions
-        const txs = await Promise.all(transactions.map(async transaction => {
-          return this.getMethod('decodeRawTransaction')(transaction)
-        }))
-        claimSwapTransaction = txs
-          .reduce((acc, val) => acc.concat({ hash: val.hash, vin: val._raw.data.vin }), [])
-          .map(val => val.vin.map(vin => { return { hash: val.hash, vin: vin } }))
-          .flat()
-          .find(tx => tx.vin.txid === initiationTxHash)
+        claimSwapTransaction = block.transactions.find(tx =>
+          tx._raw.data.vin.find(vin => vin.txid === initiationTxHash)
+        )
         blockNumber++
       }
       await sleep(5000)

--- a/src/providers/bitcoin/BitcoinSwapProvider.js
+++ b/src/providers/bitcoin/BitcoinSwapProvider.js
@@ -174,7 +174,7 @@ export default class BitcoinSwapProvider extends Provider {
     }
 
     return {
-      hash: claimSwapTransaction.hash, // TODO: full transaction object
+      ...claimSwapTransaction,
       secret: await this.getSwapSecret(claimSwapTransaction.hash)
     }
   }

--- a/src/providers/bitcoin/BitcoinSwapProvider.js
+++ b/src/providers/bitcoin/BitcoinSwapProvider.js
@@ -131,7 +131,7 @@ export default class BitcoinSwapProvider extends Provider {
     return this._spendSwap(signature, pubKey, false)
   }
 
-  async findInitiateSwapTransaction (recipientAddress, refundAddress, secretHash, expiration) {
+  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration) {
     const data = this.createSwapScript(recipientAddress, refundAddress, secretHash, expiration)
     const scriptPubKey = padHexStart(data)
     const receivingAddress = pubKeyToAddress(scriptPubKey, this._network.name, 'scriptHash')
@@ -152,9 +152,9 @@ export default class BitcoinSwapProvider extends Provider {
         initiateSwapTransaction = txs
           .map(transaction => transaction._raw.data)
           .map(transaction => transaction.vout
-            .map(vout => { return { txid: transaction.txid, scriptPubKey: vout.scriptPubKey } }))
+            .map(vout => { return { txid: transaction.txid, scriptPubKey: vout.scriptPubKey, value: vout.valueSat } }))
           .reduce((acc, val) => acc.concat(val), [])
-          .find(txKeys => txKeys.scriptPubKey.hex === sendScript)
+          .find(txInfo => txInfo.scriptPubKey.hex === sendScript && txInfo.value === value)
         blockNumber++
       }
       await sleep(5000)

--- a/src/providers/ethereum/EthereumSwapProvider.js
+++ b/src/providers/ethereum/EthereumSwapProvider.js
@@ -95,14 +95,16 @@ export default class EthereumSwapProvider extends Provider {
     return ''
   }
 
-  async findInitiateSwapTransaction (recipientAddress, refundAddress, secretHash, expiration) {
+  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration) {
     const data = this.createSwapScript(recipientAddress, refundAddress, secretHash, expiration)
     let blockNumber = await this.getMethod('getBlockHeight')()
     let initiateSwapTransaction = null
     while (!initiateSwapTransaction) {
       const block = await this.getMethod('getBlockByNumber')(blockNumber, true)
       if (block) {
-        initiateSwapTransaction = block.transactions.find(transaction => transaction.input === data.toLowerCase())
+        initiateSwapTransaction = block.transactions.find(transaction =>
+          transaction.input === data.toLowerCase() && transaction.value === value
+        )
         blockNumber++
       }
       await sleep(5000)

--- a/src/providers/ethereum/EthereumSwapProvider.js
+++ b/src/providers/ethereum/EthereumSwapProvider.js
@@ -122,12 +122,12 @@ export default class EthereumSwapProvider extends Provider {
   }
 
   async findClaimSwapTransaction (initiationTxHash, secretHash) {
-    const initiationTransaction = await this.getMethod('getTransactionReceipt')(initiationTxHash)
     let blockNumber = await this.getMethod('getBlockHeight')()
     let claimSwapTransaction = null
     while (!claimSwapTransaction) {
+      const initiationTransaction = await this.getMethod('getTransactionReceipt')(initiationTxHash)
       const block = await this.getMethod('getBlockByNumber')(blockNumber, true)
-      if (block) {
+      if (block && initiationTransaction) {
         claimSwapTransaction = block.transactions.find(transaction => transaction.to === initiationTransaction.contractAddress)
         blockNumber++
       }

--- a/src/providers/ethereum/EthereumSwapProvider.js
+++ b/src/providers/ethereum/EthereumSwapProvider.js
@@ -1,6 +1,6 @@
 import Provider from '../../Provider'
 import { padHexStart } from '../../crypto'
-import { ensureHexStandardFormat } from './EthereumUtil'
+import { ensureAddressStandardFormat } from './EthereumUtil'
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
@@ -67,11 +67,11 @@ export default class EthereumSwapProvider extends Provider {
       '00', // STOP
 
       '5b', // JUMPDEST
-      '73', ensureHexStandardFormat(recipientAddress), // PUSH20 {recipientAddressEncoded}
+      '73', ensureAddressStandardFormat(recipientAddress), // PUSH20 {recipientAddressEncoded}
       'ff', // SUICIDE
 
       '5b', // JUMPDEST
-      '73', ensureHexStandardFormat(refundAddress), // PUSH20 {refundAddressEncoded}
+      '73', ensureAddressStandardFormat(refundAddress), // PUSH20 {refundAddressEncoded}
       'ff' // SUICIDE
     ].join('')
   }
@@ -97,7 +97,7 @@ export default class EthereumSwapProvider extends Provider {
 
   doesTransactionMatchSwapParams (transaction, value, recipientAddress, refundAddress, secretHash, expiration) {
     const data = this.createSwapScript(recipientAddress, refundAddress, secretHash, expiration)
-    return transaction.input === data.toLowerCase() && transaction.value === value
+    return transaction.input === data && transaction.value === value
   }
 
   async verifyInitiateSwapTransaction (initiationTxHash, value, recipientAddress, refundAddress, secretHash, expiration) {

--- a/src/providers/ethereum/EthereumUtil.js
+++ b/src/providers/ethereum/EthereumUtil.js
@@ -27,6 +27,7 @@ function formatEthResponse (obj) {
     obj = obj.map(ensureHexStandardFormat)
   } else {
     for (let key in obj) {
+      if (obj[key] === null) continue
       if (Array.isArray(obj[key])) {
         obj[key] = formatEthResponse(obj[key])
       } else {
@@ -46,4 +47,13 @@ function formatEthResponse (obj) {
   return obj
 }
 
-export {ensureHexEthFormat, ensureHexStandardFormat, formatEthResponse}
+function normalizeTransactionObject (tx, currentBlock) {
+  if (tx.blockNumber === null) {
+    delete tx.blockNumber
+  } else if (!isNaN(tx.blockNumber)) {
+    tx.confirmations = currentBlock - tx.blockNumber + 1
+  }
+  return tx
+}
+
+export { ensureHexEthFormat, ensureHexStandardFormat, formatEthResponse, normalizeTransactionObject }

--- a/src/providers/ethereum/EthereumUtil.js
+++ b/src/providers/ethereum/EthereumUtil.js
@@ -16,6 +16,14 @@ function ensureHexStandardFormat (hash) {
   return hash.replace('0x', '')
 }
 
+/**
+ * Converts an ethereum address to the standard format
+ * @param {*} address
+ */
+function ensureAddressStandardFormat (address) {
+  return ensureHexStandardFormat(address).toLowerCase()
+}
+
 function formatEthResponse (obj) {
   if (typeof obj === 'string' || obj instanceof String) {
     obj = ensureHexStandardFormat(obj)
@@ -56,4 +64,4 @@ function normalizeTransactionObject (tx, currentBlock) {
   return tx
 }
 
-export { ensureHexEthFormat, ensureHexStandardFormat, formatEthResponse, normalizeTransactionObject }
+export { ensureHexEthFormat, ensureHexStandardFormat, ensureAddressStandardFormat, formatEthResponse, normalizeTransactionObject }

--- a/src/schema/Transaction.json
+++ b/src/schema/Transaction.json
@@ -25,6 +25,11 @@
       "title": "Value",
       "minimum": 0
     },
+    "confirmations": {
+      "type": "number",
+      "title": "Confirmations",
+      "minimum": 0
+    },
     "_raw": {
       "type": "object"
     }


### PR DESCRIPTION
### Description

Adds the verify swap method and makes sure find transaction methods return a full transaction object.

### Submission Checklist :pencil:

- [x] Bitcoin swap provider find functions return full tx object
- [x] Add verify swap method
- [x] Simplify a little looking for transactions in a block
- [x] Add confirmations to the standard tx object
- [x] Ensure eth transaction objects are normalized
- [x] Standardise eth addresses for the swap provider