### PR TITLE
Validate network id MetaMask provider

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -562,4 +562,19 @@ export default class Client {
 
     return this.getMethod('refundSwap')(initiationTxHash, recipientAddress, refundAddress, secretHash, expiration)
   }
+
+  async getWalletNetworkId () {
+    return this.getMethod('getWalletNetworkId')()
+  }
+
+  async getRPCNetworkId () {
+    return this.getMethod('getRPCNetworkId')()
+  }
+
+  async ensureNetworkId () {
+    const walletNetworkId = await this.getMethod('getWalletNetworkId')()
+    const rpcNetworkId = await this.getMethod('getRPCNetworkId')()
+
+    return walletNetworkId === rpcNetworkId
+  }
 }

--- a/src/Client.js
+++ b/src/Client.js
@@ -566,15 +566,4 @@ export default class Client {
   async getWalletNetworkId () {
     return this.getMethod('getWalletNetworkId')()
   }
-
-  async getRPCNetworkId () {
-    return this.getMethod('getRPCNetworkId')()
-  }
-
-  async ensureNetworkId () {
-    const walletNetworkId = await this.getMethod('getWalletNetworkId')()
-    const rpcNetworkId = await this.getMethod('getRPCNetworkId')()
-
-    return walletNetworkId === rpcNetworkId
-  }
 }

--- a/src/providers/ethereum/EthereumMetaMaskProvider.js
+++ b/src/providers/ethereum/EthereumMetaMaskProvider.js
@@ -5,13 +5,14 @@ import { formatEthResponse, ensureHexEthFormat, ensureHexStandardFormat } from '
 import { BigNumber } from 'bignumber.js'
 
 export default class EthereumMetaMaskProvider extends Provider {
-  constructor (metamaskProvider) {
+  constructor (metamaskProvider, networkId) {
     super()
     if (!isFunction(metamaskProvider.sendAsync)) {
       throw new Error('Invalid MetaMask Provider')
     }
 
     this._metamaskProvider = metamaskProvider
+    this._networkId = parseInt(networkId)
   }
 
   _toMM (method, ...params) {
@@ -66,6 +67,14 @@ export default class EthereumMetaMaskProvider extends Provider {
   }
 
   async sendTransaction (to, value, data, from = null) {
+    const networkId = await this.getWalletNetworkId()
+
+    if (this._networkId) {
+      if (networkId !== this._networkId) {
+        throw new Error('Invalid MetaMask Network')
+      }
+    }
+
     if (to != null) {
       to = ensureHexEthFormat(to)
     }

--- a/src/providers/ethereum/EthereumMetaMaskProvider.js
+++ b/src/providers/ethereum/EthereumMetaMaskProvider.js
@@ -87,4 +87,8 @@ export default class EthereumMetaMaskProvider extends Provider {
     const txHash = await this._toMM('eth_sendTransaction', tx)
     return ensureHexStandardFormat(txHash)
   }
+
+  async getWalletNetworkId () {
+    return this._toMM('net_version')
+  }
 }

--- a/src/providers/ethereum/EthereumMetaMaskProvider.js
+++ b/src/providers/ethereum/EthereumMetaMaskProvider.js
@@ -98,6 +98,8 @@ export default class EthereumMetaMaskProvider extends Provider {
   }
 
   async getWalletNetworkId () {
-    return this._toMM('net_version')
+    const networkId = await this._toMM('net_version')
+
+    return parseInt(networkId)
   }
 }

--- a/src/providers/ethereum/EthereumRPCProvider.js
+++ b/src/providers/ethereum/EthereumRPCProvider.js
@@ -95,8 +95,4 @@ export default class EthereumRPCProvider extends JsonRpcProvider {
 
     return transactionCount > 0
   }
-
-  async getRPCNetworkId () {
-    return this.jsonrpc('net_version')
-  }
 }

--- a/src/providers/ethereum/EthereumRPCProvider.js
+++ b/src/providers/ethereum/EthereumRPCProvider.js
@@ -95,4 +95,8 @@ export default class EthereumRPCProvider extends JsonRpcProvider {
 
     return transactionCount > 0
   }
+
+  async getRPCNetworkId () {
+    return this.jsonrpc('net_version')
+  }
 }


### PR DESCRIPTION
### Description

Currently it's possible to have an interface where the rpc provider has one network id, and the wallet provider has a different network id, causing confusion. This PR ensures that there is a function to check if the network id is different between these providers. 

When users setup MetaMask provider, they can specify `networkId` if they want to, and validation will be done on `networkId` to ensure MetaMask is on the right network. 

`EthereumMetaMaskProvider(web3.currentProvider, 4)`

### Submission Checklist :pencil:

- [x] Add getWalletNetworkId
