### PR TITLE
Improve finding swap transactions

### DIFF
--- a/examples/swap/swap-e2e.html
+++ b/examples/swap/swap-e2e.html
@@ -105,12 +105,12 @@
     /* global $, ChainAbstractionLayer, web3 */
     const { Client, providers, networks, crypto } = ChainAbstractionLayer
     const bitcoin = new Client()
-    bitcoin.addProvider(new providers.bitcoin.BitcoreRPCProvider('https://localhost:18332', 'bitcoin', 'local321'))
+    bitcoin.addProvider(new providers.bitcoin.BitcoreRPCProvider('http://localhost:18332', 'bitcoin', 'local321'))
     bitcoin.addProvider(new providers.bitcoin.BitcoinLedgerProvider({ network: networks.bitcoin_testnet, segwit: false }))
     bitcoin.addProvider(new providers.bitcoin.BitcoinSwapProvider({ network: networks.bitcoin_testnet }))
 
     const ethereum = new Client()
-    ethereum.addProvider(new providers.ethereum.EthereumRPCProvider('https://localhost:8545'))
+    ethereum.addProvider(new providers.ethereum.EthereumRPCProvider('http://localhost:8545'))
     ethereum.addProvider(new providers.ethereum.EthereumMetaMaskProvider(web3.currentProvider))
     ethereum.addProvider(new providers.ethereum.EthereumSwapProvider())
 
@@ -174,7 +174,7 @@
         $(`#${prefix}FindClaimSwap`).show()
       })
 
-      client.findClaimSwapTransaction(initiationTxHash, secretHash).then(result => {
+      client.findClaimSwapTransaction(initiationTxHash, recipientAddress, refundAddress, secretHash, expiration).then(result => {
         $(`#${prefix}FindClaimSwapTransactionResult`).text(JSON.stringify(result, null, 2))
         $(`#${prefix}FindClaimSwapTransactionResultSecret`).text(result.secret)
         $(`#${prefix}FindClaimSwapSecret`).show()

--- a/src/Client.js
+++ b/src/Client.js
@@ -386,9 +386,9 @@ export default class Client {
   /**
    * Find swap transaction from parameters
    * @param {!number} value - The amount of native value locked in the swap
-   * @param {!string} blockNumber - Block number in which transaction was mined
    * @param {!string} recipientAddress - Recepient address
    * @param {!string} refundAddress - Refund address
+   * @param {!string} secretHash - Secret hash
    * @param {!string} expiration - Expiration time
    * @return {Promise<string>} Resolves with a transaction identifier.
    */
@@ -398,13 +398,15 @@ export default class Client {
 
   /**
    * Find swap claim transaction from parameters
-   * @param {!string} blockNumber - Block number in which transaction was mined
    * @param {!string} initiationTxHash - Swap initiation transaction hash/identifier
+   * @param {!string} recipientAddress - Recepient address
+   * @param {!string} refundAddress - Refund address
    * @param {!string} secretHash - Secret hash
+   * @param {!string} expiration - Expiration time
    * @return {Promise<string>} Resolves with a transaction identifier.
    */
-  async findClaimSwapTransaction (initiationTxHash, secretHash) {
-    return this.getMethod('findClaimSwapTransaction')(initiationTxHash, secretHash)
+  async findClaimSwapTransaction (initiationTxHash, recipientAddress, refundAddress, secretHash, expiration) {
+    return this.getMethod('findClaimSwapTransaction')(initiationTxHash, recipientAddress, refundAddress, secretHash, expiration)
   }
 
   /**

--- a/src/providers/bitcoin/BitcoreRPCProvider.js
+++ b/src/providers/bitcoin/BitcoreRPCProvider.js
@@ -35,4 +35,8 @@ export default class BitcoreRPCProvider extends BitcoinRPCProvider {
   async getAddressUtxos (addresses) {
     return this.jsonrpc('getaddressutxos', { 'addresses': addresses })
   }
+
+  async getAddressTransactions (address, start, end) {
+    return this.jsonrpc('getaddresstxids', { 'addresses': [address], start, end })
+  }
 }


### PR DESCRIPTION
### Description

The method for finding the swap transactions would parse blocks and every transaction in that to find it. This was innefficient and on mainnet could make thousands of network calls (per tx) and take minutes

We need a more efficient way

### Submission Checklist :pencil:

- [x] Add `getAddressTransactions` to BitcoreRPCProvider - One call to get matching transactions in a block