### PR TITLE
Fix relayfee amount with BigNumber

### DIFF
--- a/src/providers/bitcoin/BitcoinSwapProvider.js
+++ b/src/providers/bitcoin/BitcoinSwapProvider.js
@@ -1,5 +1,6 @@
 import Provider from '../../Provider'
 import { addressToPubKeyHash, compressPubKey, pubKeyToAddress, reverseBuffer, scriptNumEncode } from './BitcoinUtil'
+import { BigNumber } from 'bignumber.js'
 import { sha256, padHexStart } from '../../crypto'
 import networks from '../../networks'
 
@@ -230,7 +231,7 @@ export default class BitcoinSwapProvider extends Provider {
     const value = parseInt(reverseBuffer(output.amount).toString('hex'), 16)
     const { relayfee } = await this.getMethod('jsonrpc')('getinfo')
     const fee = this.getMethod('calculateFee')(1, 1, feePerByte)
-    const amount = value - Math.max(fee, relayfee)
+    const amount = value - Math.max(fee, BigNumber(relayfee).times(1e8).toNumber())
     const amountLE = Buffer.from(padHexStart(amount.toString(16), 16), 'hex').reverse().toString('hex') // amount in little endian
     const pubKeyHash = addressToPubKeyHash(address)
 


### PR DESCRIPTION
### Description

Previously when generating tx, we were comparing `relayfee` with `fee` ( `Math.max(fee, BigNumber(relayfee).times(1e8).toNumber())` ) so, if the fee was 67, then it would compare it to `0.0001`. This ensures that it's comparing the satoshi values, rather than satoshi to btc 
