### PR TITLE
Cache xpubkey

### DIFF
--- a/src/providers/bitcoin/BitcoinLedgerProvider.js
+++ b/src/providers/bitcoin/BitcoinLedgerProvider.js
@@ -16,6 +16,7 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
     this._bjsnetwork = chain.network.name.replace('bitcoin_', '') // for bitcoin js
     this._segwit = chain.segwit
     this._coinType = chain.network.coinType
+    this._extendedPubKeyCache = {}
   }
 
   async getPubKey (from) {
@@ -25,7 +26,7 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
     return app.getWalletPublicKey(derivationPath)
   }
 
-  async getAddressExtendedPubKey (path) {
+  async _getAddressExtendedPubKey (path) {
     const app = await this.getApp()
     var parts = path.split('/')
     var prevPath = parts[0] + '/' + parts[1]
@@ -57,6 +58,16 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
       ((result[0] << 24) | (result[1] << 16) | (result[2] << 8) | result[3]) >>>
       0
     return finalize(fingerprint)
+  }
+
+  async getAddressExtendedPubKey (path) {
+    if (path in this._extendedPubKeyCache) {
+      return this._extendedPubKeyCache[path]
+    }
+
+    const extendedPubKey = this._getAddressExtendedPubKey(path)
+    this._extendedPubKeyCache[path] = extendedPubKey
+    return extendedPubKey
   }
 
   async getAddressFromDerivationPath (path) {

--- a/webpack/webpack.browser.config.js
+++ b/webpack/webpack.browser.config.js
@@ -18,5 +18,5 @@ module.exports = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   plugins: plugins({ target: 'web' }),
   watch: process.env.WEBPACK_WATCH === 'true',
-  node: { Buffer: false }
+  node: { Buffer: process.env.NODE_ENV !== 'production' }
 }


### PR DESCRIPTION
### Description

Cache the xpubkey by path. This prevents too many unneeded calls to export pub key to the ledger. 
For a typical use cases reduces 8 calls to export key to 2 
2 is required because the paths differ and have to be individually exported. 

### Submission Checklist :pencil:

- [x] Cache the xpubkey when it is generated
- [x] Fix the browser dev webpack config so it includes buffer
