### PR TITLE
Add segwit to createPaymentTransactionNew

### DIFF
--- a/src/providers/bitcoin/BitcoinLedgerProvider.js
+++ b/src/providers/bitcoin/BitcoinLedgerProvider.js
@@ -403,7 +403,7 @@ async getUtxosForAmount (amount, numAddressPerCall = 10) {
       outputs.push({ amount: this.getAmountBuffer(changeAmount), script: Buffer.from(changeScript, 'hex') })
     }
     const serializedOutputs = app.serializeTransactionOutputs({ outputs }).toString('hex')
-    const signedTransaction = await app.createPaymentTransactionNew(ledgerInputs, paths, unusedAddress.derivationPath, serializedOutputs)
+    const signedTransaction = await app.createPaymentTransactionNew(ledgerInputs, paths, unusedAddress.derivationPath, serializedOutputs, 0, 1, true)
     return this.getMethod('sendRawTransaction')(signedTransaction)
   }
 


### PR DESCRIPTION
### Description

This PR adds segwit boolean to `createPaymentTransactionNew`. There was an issue discovered where a legacy address wasn't able to spend from a utxo that has a bech32 address as an input (i.e. https://blockstream.info/address/1Bo1izLAGGFqoHyyrrK9vaXY9TiRJUVTmR) 

### Submission Checklist :pencil:

- [x] Add segwit boolean to `createPaymentTransactionNew`