### PR TITLE
Wallet providers assert matching network

### DIFF
--- a/src/providers/LedgerProvider.js
+++ b/src/providers/LedgerProvider.js
@@ -7,11 +7,12 @@ export default class LedgerProvider extends WalletProvider {
     return Transport.isSupported()
   }
 
-  constructor (App, baseDerivationPath) {
-    super()
+  constructor (App, baseDerivationPath, network) {
+    super(network)
 
     this._App = App
     this._baseDerivationPath = baseDerivationPath
+    this._network = network
     this._addressCache = {}
   }
 

--- a/src/providers/LedgerProvider.js
+++ b/src/providers/LedgerProvider.js
@@ -1,8 +1,8 @@
 import Transport from '@ledgerhq/hw-transport-node-hid'
-import Provider from '../Provider'
+import WalletProvider from './WalletProvider'
 import { WalletError } from '../errors'
 
-export default class LedgerProvider extends Provider {
+export default class LedgerProvider extends WalletProvider {
   static isSupported () {
     return Transport.isSupported()
   }
@@ -26,8 +26,8 @@ export default class LedgerProvider extends Provider {
   }
 
   errorProxy (target, func) {
-    if (Object.getOwnPropertyNames(target).includes(func)) {
-      const method = target[func]
+    const method = target[func]
+    if (Object.getOwnPropertyNames(target).includes(func) && typeof method === 'function') {
       return async (...args) => {
         try {
           const result = await method.bind(target)(...args)
@@ -38,7 +38,7 @@ export default class LedgerProvider extends Provider {
         }
       }
     } else {
-      return target[func]
+      return method
     }
   }
 
@@ -55,6 +55,11 @@ export default class LedgerProvider extends Provider {
     }
 
     return this._appInstance
+  }
+
+  async getConnectedNetwork () {
+    // Ledger apps do not provide connected network. It is separated in firmware.
+    return this._network
   }
 
   getDerivationPathFromIndex (index, change = false) {

--- a/src/providers/WalletProvider.js
+++ b/src/providers/WalletProvider.js
@@ -1,0 +1,57 @@
+import _ from 'lodash'
+import Provider from '../Provider'
+import { WalletError } from '../errors'
+
+export default class WalletProvider extends Provider {
+  constructor (network) {
+    super()
+    this._network = network
+    this._methods = Object.getOwnPropertyNames(WalletProvider.prototype)
+      .filter(method => ![
+        'constructor',
+        '_networkMatchProxy',
+        'getConnectedNetwork',
+        'assertNetworkMatch'
+      ].includes(method))
+    return network ? new Proxy(this, { get: this._networkMatchProxy.bind(this) }) : this
+  }
+
+  _networkMatchProxy (target, func) {
+    const method = target[func]
+    if (this._methods.includes(func)) {
+      return async (...args) => {
+        await this.assertNetworkMatch()
+        return method.bind(target)(...args)
+      }
+    } else {
+      return method
+    }
+  }
+
+  async assertNetworkMatch () {
+    const connectedNetwork = await this.getConnectedNetwork()
+    if (!_.isEqual(connectedNetwork, this._network)) {
+      throw new WalletError(`Network mismatch. Configured network '${this._network.name}' does not match connected network '${connectedNetwork.name}'`)
+    }
+  }
+
+  getAddresses () {
+    throw new Error('getAddresses not implemented.')
+  }
+
+  getUsedAddresses () {
+    throw new Error('getUsedAddresses not implemented.')
+  }
+
+  getUnusedAddresses () {
+    throw new Error('getUnusedAddresses not implemented.')
+  }
+
+  signMessage () {
+    throw new Error('signMessage not implemented.')
+  }
+
+  async getConnectedNetwork () {
+    throw new Error('getConnectedNetwork not implemented.')
+  }
+}

--- a/src/providers/bitcoin/BitcoinLedgerProvider.js
+++ b/src/providers/bitcoin/BitcoinLedgerProvider.js
@@ -3,14 +3,14 @@ import Bitcoin from '@ledgerhq/hw-app-btc'
 
 import { BigNumber } from 'bignumber.js'
 import { base58, padHexStart } from '../../crypto'
-import { pubKeyToAddress, addressToPubKeyHash, compressPubKey } from './BitcoinUtil'
+import { pubKeyToAddress, addressToPubKeyHash, compressPubKey, getAddressNetwork } from './BitcoinUtil'
 import Address from '../../Address'
 import networks from './networks'
 import bip32 from 'bip32'
 
 export default class BitcoinLedgerProvider extends LedgerProvider {
   constructor (chain = { network: networks.bitcoin, segwit: false }, numberOfBlockConfirmation = 1) {
-    super(Bitcoin, `${chain.segwit ? '49' : '44'}'/${chain.network.coinType}'/0'/`)
+    super(Bitcoin, `${chain.segwit ? '49' : '44'}'/${chain.network.coinType}'/0'/`, chain.network)
     this._derivationPath = `${chain.segwit ? '49' : '44'}'/${chain.network.coinType}'/0'/`
     this._network = chain.network
     this._bjsnetwork = chain.network.name.replace('bitcoin_', '') // for bitcoin js
@@ -501,5 +501,11 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
 
   async getAddresses (startingIndex = 0, numAddresses = 1, change = false) {
     return this.getLedgerAddresses(startingIndex, numAddresses, change)
+  }
+
+  async getConnectedNetwork () {
+    const walletPubKey = await this.getWalletPublicKey(this._baseDerivationPath)
+    const network = getAddressNetwork(walletPubKey.bitcoinAddress)
+    return network
   }
 }

--- a/src/providers/bitcoin/BitcoinUtil.js
+++ b/src/providers/bitcoin/BitcoinUtil.js
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 import {
   ensureBuffer,
   hash160,
@@ -112,6 +114,17 @@ function toHexInt (number) {
     toHexDigit(number & 0xff)
   )
 }
+/**
+ * Get a network object from an address
+ * @param {string} address The bitcoin address
+ * @return {Network}
+ */
+function getAddressNetwork (address) {
+  const prefix = base58.decode(address).toString('hex').substring(0, 2).toUpperCase()
+  const networkKey = _.findKey(networks,
+    network => [network.pubKeyHash, network.scriptHash].includes(prefix))
+  return networks[networkKey]
+}
 
 export {
   toHexInt,
@@ -120,5 +133,6 @@ export {
   pubKeyHashToAddress,
   addressToPubKeyHash,
   reverseBuffer,
-  scriptNumEncode
+  scriptNumEncode,
+  getAddressNetwork
 }

--- a/src/providers/ethereum/EthereumMetaMaskProvider.js
+++ b/src/providers/ethereum/EthereumMetaMaskProvider.js
@@ -1,13 +1,14 @@
-import { isFunction } from 'lodash'
+import _ from 'lodash'
 import { BigNumber } from 'bignumber.js'
-import Provider from '../../Provider'
+import WalletProvider from '../WalletProvider'
 import { formatEthResponse, ensureHexEthFormat, ensureHexStandardFormat } from './EthereumUtil'
 import { WalletError } from '../../errors'
+import networks from './networks'
 
-export default class EthereumMetaMaskProvider extends Provider {
+export default class EthereumMetaMaskProvider extends WalletProvider {
   constructor (metamaskProvider, network) {
-    super()
-    if (!isFunction(metamaskProvider.sendAsync)) {
+    super(network)
+    if (!_.isFunction(metamaskProvider.sendAsync)) {
       throw new Error('Invalid MetaMask Provider')
     }
 
@@ -110,5 +111,14 @@ export default class EthereumMetaMaskProvider extends Provider {
     const networkId = await this._toMM('net_version')
 
     return parseInt(networkId)
+  }
+
+  async getConnectedNetwork () {
+    const networkId = await this.getWalletNetworkId()
+    const network = _.findKey(networks, network => network.networkId === networkId)
+    if (networkId && !network) {
+      return { name: 'unknown', networkId }
+    }
+    return networks[network]
   }
 }

--- a/test/integration/swap/common.js
+++ b/test/integration/swap/common.js
@@ -15,9 +15,10 @@ const bitcoinWithNode = new Client()
 bitcoinWithNode.addProvider(new providers.bitcoin.BitcoreRPCProvider(config.bitcoin.rpc.host, config.bitcoin.rpc.username, config.bitcoin.rpc.password))
 bitcoinWithNode.addProvider(new providers.bitcoin.BitcoinJsLibSwapProvider({ network: bitcoinNetworks[config.bitcoin.network] }))
 
+const ethereumNetworks = providers.ethereum.networks
 const ethereumWithMetaMask = new Client()
 ethereumWithMetaMask.addProvider(new providers.ethereum.EthereumRPCProvider(config.ethereum.rpc.host))
-ethereumWithMetaMask.addProvider(new providers.ethereum.EthereumMetaMaskProvider(metaMaskConnector.getProvider()))
+ethereumWithMetaMask.addProvider(new providers.ethereum.EthereumMetaMaskProvider(metaMaskConnector.getProvider(), ethereumNetworks[config.ethereum.network]))
 ethereumWithMetaMask.addProvider(new providers.ethereum.EthereumSwapProvider())
 
 const ethereumWithNode = new Client()


### PR DESCRIPTION
### Description

Wallet providers need to have a method of determining whether they are on the right network. Also, this should be asserted before sending a request to the wallet. 

### Submission Checklist :pencil:

- [x] Set in place the interface for wallet providers.
- [x] Add mechanism for Wallet providers to always check the network before calls. 
- [x] Implemented `getConnectedNetwork` for metamask provider
- [x] Implementation for `LedgerProvider` ?
