### PR TITLE
BitcoinSwapProvider: Not enough value claim error

### DIFF
--- a/src/providers/bitcoin/BitcoinSwapProvider.js
+++ b/src/providers/bitcoin/BitcoinSwapProvider.js
@@ -228,8 +228,14 @@ export default class BitcoinSwapProvider extends Provider {
     const output = initiationTx.outputs[voutIndex]
     const value = parseInt(reverseBuffer(output.amount).toString('hex'), 16)
     const { relayfee } = await this.getMethod('jsonrpc')('getinfo')
-    const fee = this.getMethod('calculateFee')(1, 1, feePerByte)
-    const amount = value - Math.max(fee, BigNumber(relayfee).times(1e8).toNumber())
+    const calculatedFee = this.getMethod('calculateFee')(1, 1, feePerByte)
+    const fee = Math.max(calculatedFee, BigNumber(relayfee).times(1e8).toNumber())
+    const amount = value - fee
+
+    if (amount < 0) {
+      throw new Error('Not enough value in transaction to pay fee.')
+    }
+
     const amountLE = Buffer.from(padHexStart(amount.toString(16), 16), 'hex').reverse().toString('hex') // amount in little endian
     const pubKeyHash = addressToPubKeyHash(address)
 

--- a/src/providers/bitcoin/BitcoinSwapProvider.js
+++ b/src/providers/bitcoin/BitcoinSwapProvider.js
@@ -229,8 +229,8 @@ export default class BitcoinSwapProvider extends Provider {
     const value = parseInt(reverseBuffer(output.amount).toString('hex'), 16)
     const { relayfee } = await this.getMethod('jsonrpc')('getinfo')
     const calculatedFee = this.getMethod('calculateFee')(1, 1, feePerByte)
-    const fee = Math.max(calculatedFee, BigNumber(relayfee).times(1e8).toNumber())
-    const amount = value - fee
+    const fee = BigNumber.max(calculatedFee, BigNumber(relayfee).times(1e8).toNumber())
+    const amount = BigNumber(value).minus(fee).toNumber()
 
     if (amount < 0) {
       throw new Error('Not enough value in transaction to pay fee.')


### PR DESCRIPTION
### Description

When the value locked in the swap is smaller than the fee required to send the transaction, the library does not fail and continues to request a signature from the ledger for a negative amount. 
This PR ensures that an error is thrown in that case.

