### PR TITLE
Add pubkey to get ledger addresses

### DIFF
--- a/src/providers/bitcoin/BitcoinLedgerProvider.js
+++ b/src/providers/bitcoin/BitcoinLedgerProvider.js
@@ -443,7 +443,7 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
       const path = this._baseDerivationPath + changeVal + '/' + currentIndex
       addresses.push({
         address,
-        pubkey,
+        pubkey: pubkey.toString('hex'),
         derivationPath: path,
         index: currentIndex
       })

--- a/src/providers/bitcoin/BitcoinLedgerProvider.js
+++ b/src/providers/bitcoin/BitcoinLedgerProvider.js
@@ -438,10 +438,12 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
     const xpubkeys = await this.getAddressExtendedPubKeys(this._baseDerivationPath)
     const node = bip32.fromBase58(xpubkeys[0], this._network)
     for (let currentIndex = startingIndex; currentIndex < lastIndex; currentIndex++) {
-      const address = pubKeyToAddress(node.derivePath(changeVal + '/' + currentIndex).__Q, this._network.name, 'pubKeyHash')
+      const pubkey = node.derivePath(changeVal + '/' + currentIndex).__Q
+      const address = pubKeyToAddress(pubkey, this._network.name, 'pubKeyHash')
       const path = this._baseDerivationPath + changeVal + '/' + currentIndex
       addresses.push({
         address,
+        pubkey,
         derivationPath: path,
         index: currentIndex
       })


### PR DESCRIPTION
### Description

This PR modifies `getLedgerAddresses` to get `pubkey` along with `address`,`derivationPath` and `index`. This is important because pubkey is used with certain op_codes in Bitcoin, such as `OP_CHECKMULTISIG`

### Submission Checklist :pencil:

- [x] return `pubkey` with `getLedgerAddresses`
